### PR TITLE
Use pyperclip for cross-platform clipboard copy

### DIFF
--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import subprocess
 import openai
+import pyperclip
 import os
 from urllib.parse import quote
 from simple_term_menu import TerminalMenu
@@ -92,7 +93,7 @@ The command the user is looking for is:
         os.system(cmd)
     elif menu_entry_index == 1:
         print("> copied")
-        subprocess.run(["pbcopy"], input=cmd, encoding="utf-8")
+        pyperclip.copy(cmd)
     elif menu_entry_index == 2:
         link = "https://explainshell.com/explain?cmd=" + quote(cmd)
         print("> explainshell: " + link)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ openai>=0.25.0
 openpyxl>=3.0.10
 pandas>=1.3.5
 python-dateutil>=2.8.2
+pyperclip>=1.8.2
 pytz>=2022.6
 requests>=2.28.1
 six>=1.16.0


### PR DESCRIPTION
The currently used `pbcopy` command is a MacOS only command. Using pyperclip allows for copying the returned command to the clipboard cross-platform.

Please do let me know if any additional modifications should be made.