### PR TITLE
Include last 40 commands of fish history in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,20 @@ Here are some examples of how you can use terminal-copilot:
 3. `copilot install the openai package for python`
 4. `copilot clean up my docker images`
 
+### Arguments
+Terminal-copilot can be called with optional command line arguments to modify its behavior. These arguments can be specified when calling the copilot command in the terminal.
+
+The available arguments are:
+
+- `-a`, `--with-aliases`: Enables the inclusion of aliases in the prompt sent to the OpenAI API. May potentially send sensitive information to OpenAI.
+- `-v`, `--verbose`: Increases output verbosity of the tool.
+- `-hist`, `--history`: Enables the inclusion of terminal history in the prompt sent to the OpenAI API. May potentially send sensitive information to OpenAI and increase the number of tokens used.
+
 ### Requirements
 Python 3.7+ 
+
+### Sensitive Information
+Please note that terminal-copilot has the ability to send sensitive information to OpenAI as part of the prompt used to generate terminal commands. This includes the `--with-aliases` and `--history` command line arguments, which may include sensitive information such as aliases and terminal history. If you are concerned about the potential for sensitive information to be sent to OpenAI, we recommend not using these flags. We recommend that users exercise caution when using these optional features and consider the potential risks before enabling them.
 
 ## Development
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ Here are some examples of how you can use terminal-copilot:
 4. `copilot clean up my docker images`
 
 ### Arguments
-Terminal-copilot can be called with optional command line arguments to modify its behavior. These arguments can be specified when calling the copilot command in the terminal.
-
-The available arguments are:
+Terminal-copilot can be called with optional command line arguments:
 
 - `-a`, `--with-aliases`: Enables the inclusion of aliases in the prompt sent to the OpenAI API. May potentially send sensitive information to OpenAI.
 - `-v`, `--verbose`: Increases output verbosity of the tool.

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -19,6 +19,8 @@ def main():
                         help='include aliases in the prompt')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='increase output verbosity')
+    parser.add_argument('-hist', '--history', action='store_true',
+                        help='include terminal history in the prompt')
 
     args = parser.parse_args()
 
@@ -47,7 +49,7 @@ The user is currently in the following directory:
 {subprocess.run(["pwd"], capture_output=True).stdout.decode("utf-8")}
 That directory contains the following files:
 {subprocess.run(["ls"], capture_output=True).stdout.decode("utf-8")}
-{history.get_history()}
+{history.get_history() if args.history else ""}
 The user has several environment variables set, some of which are:
 {environs}
 """
@@ -77,13 +79,14 @@ The command the user is looking for is:
     cmd = request_cmds(prompt, n=1)[0]
     show_command_options(prompt, cmd)
 
+
 def show_command_options(prompt, cmd):
     print(f"\033[94m> {cmd}\033[0m")
     options = ["execute", "copy", "explainshell", "show more options"]
     terminal_menu = TerminalMenu(options)
     menu_entry_index = terminal_menu.show()
     if menu_entry_index == 0:
-        os.system(cmd)
+        execute(cmd)
     elif menu_entry_index == 1:
         print("> copied")
         pyperclip.copy(cmd)
@@ -93,6 +96,12 @@ def show_command_options(prompt, cmd):
         subprocess.run(["open", "https://explainshell.com/explain?cmd=" + quote(cmd)])
     elif menu_entry_index == 3:
         show_more_cmd_options(prompt)
+
+
+def execute(cmd):
+    os.system(cmd)
+    history.save(cmd)
+
 
 def show_more_cmd_options(prompt):
     cmds = request_cmds(prompt, n=5)

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 from simple_term_menu import TerminalMenu
 import platform
 
+import history
 
 def main():
     parser = argparse.ArgumentParser(prog='copilot', description='Terminal Copilot')
@@ -24,7 +25,6 @@ def main():
     if args.verbose:
         print("Verbose mode enabled")
 
-    # run history -40 to get the last 40 commands
     # TODO to get more terminal context to work with..
     # TODO save history of previous user questions and answers
 
@@ -47,6 +47,7 @@ The user is currently in the following directory:
 {subprocess.run(["pwd"], capture_output=True).stdout.decode("utf-8")}
 That directory contains the following files:
 {subprocess.run(["ls"], capture_output=True).stdout.decode("utf-8")}
+{history.get_history()}
 The user has several environment variables set, some of which are:
 {environs}
 """
@@ -98,3 +99,7 @@ The command the user is looking for is:
         link = "https://explainshell.com/explain?cmd=" + quote(cmd)
         print("> explainshell: " + link)
         subprocess.run(["open", "https://explainshell.com/explain?cmd=" + quote(cmd)])
+
+
+if __name__ == "__main__":
+    main()

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -11,16 +11,17 @@ import platform
 
 import history
 
+
 def main():
     parser = argparse.ArgumentParser(prog='copilot', description='Terminal Copilot')
     parser.add_argument('command', type=str, nargs='+',
                         help='Describe the command you are looking for.')
     parser.add_argument('-a', '--with-aliases', action='store_true',
-                        help='include aliases in the prompt')
+                        help='Include aliases in the prompt. Note: This feature may potentially send sensitive information to OpenAI.')
     parser.add_argument('-v', '--verbose', action='store_true',
-                        help='increase output verbosity')
+                        help='Increase output verbosity.')
     parser.add_argument('-hist', '--history', action='store_true',
-                        help='include terminal history in the prompt')
+                        help='Include terminal history in the prompt. Note: This feature may potentially send sensitive information to OpenAI and increase the number of tokens used.')
 
     args = parser.parse_args()
 

--- a/copilot/history.py
+++ b/copilot/history.py
@@ -1,0 +1,31 @@
+import os
+
+import history_file
+
+
+def _is_command(line):
+    return line.startswith("- cmd: ")
+
+
+def _formatted(command):
+    return command.replace("- cmd: ", "").strip()[:100]
+
+
+def _fish_history(n):
+    lines = history_file.fish_history_file_lines()
+    if len(lines) == 0:
+        return ""
+    commands = [_formatted(command) for command in lines if _is_command(command)]
+    most_recent_commands = ",".join(commands[-n:])
+    history = f"""
+The user has recently run these last {min(len(lines), n)} commands:
+{most_recent_commands}
+    """
+    return history
+
+
+def get_history(history_context_size=40):
+    if os.environ["SHELL"].endswith("fish"):
+        return _fish_history(history_context_size)
+    else:
+        return ""

--- a/copilot/history.py
+++ b/copilot/history.py
@@ -29,3 +29,7 @@ def get_history(history_context_size=40):
         return _fish_history(history_context_size)
     else:
         return ""
+
+
+def save(cmd):
+    history_file.save(cmd)

--- a/copilot/history_file.py
+++ b/copilot/history_file.py
@@ -1,0 +1,21 @@
+import os
+
+
+def _fish_history_file_location():
+    possible_paths = [
+        os.path.join(os.environ["HOME"], ".local/share/fish/fish_history"),
+        os.path.join(os.environ["HOME"], ".config/fish/fish_history"),
+    ]
+    for path in possible_paths:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def fish_history_file_lines():
+    history_file = _fish_history_file_location()
+    if history_file is None:
+        return []
+    with open(history_file, 'r') as history:
+        lines = history.readlines()
+        return lines

--- a/copilot/history_file.py
+++ b/copilot/history_file.py
@@ -1,4 +1,5 @@
 import os
+from time import time
 
 
 def _fish_history_file_location():
@@ -19,3 +20,15 @@ def fish_history_file_lines():
     with open(history_file, 'r') as history:
         lines = history.readlines()
         return lines
+
+
+def _get_history_line(command_script):
+    return u'- cmd: {}\n  when: {}\n'.format(command_script, int(time()))
+
+
+def save(cmd):
+    history_file = _fish_history_file_location()
+    if os.path.isfile(history_file):
+        with open(history_file, 'a') as history:
+            entry = _get_history_line(cmd)
+            history.write(entry)

--- a/copilot/test_history.py
+++ b/copilot/test_history.py
@@ -1,0 +1,117 @@
+import os
+
+from unittest.mock import patch
+import unittest
+
+from history import get_history
+
+
+class TestHistory(unittest.TestCase):
+    def test_get_history_add_user_history_context(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+                "- cmd: cd /home/username\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("The user has recently run these last 2 commands:" in history)
+
+    def test_get_history_limits_the_history_length_to_history_context_size(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+                "  when: 1664698037\n",
+                "- cmd: cd /home/username\n",
+                "  paths:\n",
+                "  - /home/username\n",
+            ]
+            history = get_history(1)
+        # assert
+        self.assertTrue("The user has recently run these last 1 commands:" in history)
+        self.assertFalse("ls" in history)
+
+    def test_get_history_returns_empty_string_if_no_history_file_exists_or_empty(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = []
+            history = get_history()
+        # assert
+        self.assertEqual(history, "")
+
+    def test_get_history_returns_history_if_alternative_fish_location(self):
+        # arrange
+        os.environ["SHELL"] = "/other/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("ls" in history)
+
+    def test_get_history_returns_empty_string_if_shell_is_not_set(self):
+        # arrange
+        os.environ["SHELL"] = ""
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+                "- cmd: cd /home/username\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertEqual(history, "")
+
+    def test_get_history_strips_cmd_prefix_from_commands(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("ls" in history)
+        self.assertFalse("- cmd:" in history)
+
+    def test_get_history_only_appends_commands(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+                "  when: 1611234567\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("ls" in history)
+        self.assertFalse("when:" in history)
+        self.assertFalse("1611234567" in history)
+
+    def test_get_history_only_limits_the_max_command_length_for_context_to_100(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        short_command = "ls -l /short/command"
+        long_command = "ls -l /home/username/very/long/path/that/should/be/truncated/and/this/should/be/truncated/too/this/sh" # 101 characters
+        # act
+        with patch('history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                f"- cmd: {long_command}",
+                f"- cmd: {short_command}",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue(short_command in history)
+        self.assertFalse(long_command in history)


### PR DESCRIPTION
This pull request addresses issue #8 by adding bash history support for the prompt for fish shells. This can easily be extended to support other types of shells as well. I have tested this locally and it works as expected. With this feature, you can easily refer to previous statements and terminal-copilot will pick them up.

One constraint to consider:

I have limited the maximum command length to 100 to prevent very long commands from interfering with the maximum token amount of the API. This results in an approximate maximum of around 4100 tokens. I'm open to feedback on whether this is too much or not enough. 