### PR TITLE
Allow more options

### DIFF
--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -24,7 +24,6 @@ def main():
     if args.verbose:
         print("Verbose mode enabled")
 
-    # run history -40 to get the last 40 commands
     # TODO to get more terminal context to work with..
     # TODO save history of previous user questions and answers
 
@@ -73,6 +72,35 @@ The command the user is looking for is:
         print("To set the environment variable, run:")
         print("export OPENAI_API_KEY=<your key>")
         sys.exit(1)
+    cmd = request_cmds(prompt, n=1)[0]
+    print(f"\033[94m> {cmd}\033[0m")
+    options = ["execute", "more", "copy", "explainshell"]
+    terminal_menu = TerminalMenu(options)
+    menu_entry_index = terminal_menu.show()
+    if menu_entry_index == 0:
+        os.system(cmd)
+    elif menu_entry_index == 1:
+        show_more_cmd_options(prompt)
+    elif menu_entry_index == 2:
+        print("> copied")
+        pyperclip.copy(cmd)
+    elif menu_entry_index == 3:
+        link = "https://explainshell.com/explain?cmd=" + quote(cmd)
+        print("> explainshell: " + link)
+        subprocess.run(["open", "https://explainshell.com/explain?cmd=" + quote(cmd)])
+
+
+def show_more_cmd_options(prompt):
+    cmds = request_cmds(prompt, n=5)
+    print("Here are more options:")
+    options = [repr(cmd) for cmd in cmds]
+    cmd_terminal_menu = TerminalMenu(options)
+    cmd_menu_entry_index = cmd_terminal_menu.show()
+    if cmd_menu_entry_index is not None:
+        os.system(cmds[cmd_menu_entry_index])
+
+
+def request_cmds(prompt, n=1):
     response = openai.Completion.create(
         model="text-davinci-003",
         prompt=prompt,
@@ -81,20 +109,19 @@ The command the user is looking for is:
         top_p=1,
         stop=["`"],
         frequency_penalty=0,
-        presence_penalty=0
+        presence_penalty=0,
+        n=n,
     )
-    # strip all whitespace from the response start or end
-    cmd = response.choices[0].text.strip()
-    print(f"\033[94m> {cmd}\033[0m")
-    options = ["execute", "copy", "explainshell"]
-    terminal_menu = TerminalMenu(options)
-    menu_entry_index = terminal_menu.show()
-    if menu_entry_index == 0:
-        os.system(cmd)
-    elif menu_entry_index == 1:
-        print("> copied")
-        pyperclip.copy(cmd)
-    elif menu_entry_index == 2:
-        link = "https://explainshell.com/explain?cmd=" + quote(cmd)
-        print("> explainshell: " + link)
-        subprocess.run(["open", "https://explainshell.com/explain?cmd=" + quote(cmd)])
+    choices = response.choices
+    cmds = strip_all_whitespaces_from(choices)
+    if len(cmds) > 1:
+        cmds = list(dict.fromkeys(cmds))
+    return cmds
+
+
+def strip_all_whitespaces_from(choices):
+    return [choice.text.strip() for choice in choices]
+
+
+if __name__ == "__main__":
+    main()

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -24,6 +24,7 @@ def main():
     if args.verbose:
         print("Verbose mode enabled")
 
+    # run history -40 to get the last 40 commands
     # TODO to get more terminal context to work with..
     # TODO save history of previous user questions and answers
 
@@ -121,7 +122,3 @@ def request_cmds(prompt, n=1):
 
 def strip_all_whitespaces_from(choices):
     return [choice.text.strip() for choice in choices]
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This change allows users to query for more alternative suggestions when using the terminal. The "more" option in the existing TerminalMenu will allow the user to execute one of 5 additional selections. Duplicate selections are filtered. The request to `openai.Completion.create` has also been made more generic.