### PR TITLE
Add the option to include the git context of the user if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Here are some examples of how you can use terminal-copilot:
 3. `copilot install the openai package for python`
 4. `copilot clean up my docker images`
 
+
+### Arguments
+
+- `-g`, `--git`: This flag enables the inclusion of Git context in the prompt sent to the OpenAI API. This can be useful for users working with Git repositories and may include the current branch name, repository status, recent commit messages, and file history.
+
 ### Requirements
 Python 3.7+ 
 

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -18,6 +18,8 @@ def main():
                         help='include aliases in the prompt')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='increase output verbosity')
+    parser.add_argument('-g', '--git', action='store_true',
+                        help='Include git info if available')
 
     args = parser.parse_args()
 
@@ -49,6 +51,7 @@ That directory contains the following files:
 {subprocess.run(["ls"], capture_output=True).stdout.decode("utf-8")}
 The user has several environment variables set, some of which are:
 {environs}
+{git_info() if args.git else ""}
 """
     if args.with_aliases:
         prompt += f"""
@@ -124,3 +127,23 @@ def request_cmds(prompt, n=1):
 
 def strip_all_whitespaces_from(choices):
     return [choice.text.strip() for choice in choices]
+
+
+def git_info():
+    git_installed = subprocess.run(["which", "git"], capture_output=True).returncode == 0
+    if os.path.exists(".git") and git_installed:
+        return f"""
+User is in a git repo.
+Branches are:
+{subprocess.run(["git", "branch"], capture_output=True).stdout.decode("utf-8")}
+Last 3 git history entries:
+{subprocess.run(["git", "log", "-n3", "--oneline"], capture_output=True).stdout.decode("utf-8")}
+Short git status:
+{subprocess.run(["git", "status", "-s"], capture_output=True).stdout.decode("utf-8")}
+"""
+    else:
+        return ""
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds the ability for terminal-copilot to include Git context in the prompt sent to the OpenAI API. The `--git` flag can be used to enable the inclusion of Git context in the prompt, which may include the current branch name, repository status, recent commit messages, and file history.

This feature can be useful for users working with Git repositories and may help terminal-copilot generate more accurate and targeted terminal commands.

To use this feature, pass the `--git` flag when calling terminal-copilot. 

Let me know what you think of this. 
