### PR TITLE
Disable history for windows

### DIFF
--- a/copilot/history.py
+++ b/copilot/history.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from copilot import history_file
 

--- a/copilot/history.py
+++ b/copilot/history.py
@@ -49,5 +49,8 @@ def get_history(history_context_size=40):
 
 
 def save(cmd):
+    if platform.system().lower().startswith("win"):
+        return
+    
     if os.environ["SHELL"].endswith("fish"):
         history_file.save(cmd)


### PR DESCRIPTION
Currently in the save function in history.py it checks os.environ["SHELL"] which doesn't exist on windows. This is just a quick patch to stop an ugly traceback on windows.