### PR TITLE
Add history for bash terminals

### DIFF
--- a/copilot/history.py
+++ b/copilot/history.py
@@ -1,6 +1,4 @@
-import os
-
-from copilot import history_file
+from copilot import history_file, shell_adapter
 
 
 def _is_command(line):
@@ -42,11 +40,11 @@ The user has recently run these last {min(len(commands), n)} commands:
 
 
 def get_history(n=40):
-    if os.environ["SHELL"].endswith("fish"):
+    if shell_adapter.is_fish():
         return history_prompt_for(_fish_commands(), n)
-    if os.environ["SHELL"].endswith("zsh"):
+    if shell_adapter.is_zsh():
         return history_prompt_for(_zsh_commands(), n)
-    if os.environ["SHELL"].endswith("bash"):
+    if shell_adapter.is_bash():
         return history_prompt_for(_bash_commands(), n)
     else:
         return ""

--- a/copilot/history.py
+++ b/copilot/history.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 from copilot import history_file
 
@@ -12,46 +11,46 @@ def _formatted(command):
     return command.replace("- cmd: ", "").strip()[:100]
 
 
-def _fish_history(n):
+def _fish_commands():
     lines = history_file.fish_history_file_lines()
-    if len(lines) == 0:
-        return ""
     commands = [_formatted(command) for command in lines if _is_command(command)]
-    commands = list(dict.fromkeys(commands))
-    most_recent_commands = "\n".join(commands[-n:])
-    history = f"""
-The user has recently run these last {min(len(lines), n)} commands:
-{most_recent_commands}
-    """
-    return history
+    return commands
 
 
-def _zsh_history(n):
+def _zsh_commands():
     lines = history_file.zsh_history_file_lines()
-    if len(lines) == 0:
-        return ""
     commands = [command.strip() for command in lines if command != ""]
+    return commands
+
+
+def _bash_commands():
+    lines = history_file.bash_history_file_lines()
+    commands = [command.strip() for command in lines if command != ""]
+    return commands
+
+
+def history_prompt_for(commands, n):
+    if len(commands) == 0:
+        return ""
     commands = list(dict.fromkeys(commands))
     most_recent_commands = "\n".join(commands[-n:])
     history = f"""
-The user has recently run these last {min(len(lines), n)} commands:
+The user has recently run these last {min(len(commands), n)} commands:
 {most_recent_commands}
     """
     return history
 
 
-def get_history(history_context_size=40):
+def get_history(n=40):
     if os.environ["SHELL"].endswith("fish"):
-        return _fish_history(history_context_size)
+        return history_prompt_for(_fish_commands(), n)
     if os.environ["SHELL"].endswith("zsh"):
-        return _zsh_history(history_context_size)
+        return history_prompt_for(_zsh_commands(), n)
+    if os.environ["SHELL"].endswith("bash"):
+        return history_prompt_for(_bash_commands(), n)
     else:
         return ""
 
 
 def save(cmd):
-    if platform.system().lower().startswith("win"):
-        return
-    
-    if os.environ["SHELL"].endswith("fish"):
-        history_file.save(cmd)
+    history_file.save(cmd)

--- a/copilot/history_file.py
+++ b/copilot/history_file.py
@@ -2,6 +2,8 @@ import os
 from time import time
 import platform
 
+from copilot import shell_adapter
+
 
 def _fish_history_file_location():
     possible_paths = [
@@ -76,15 +78,15 @@ def _get_bash_history_line(command_script):
 def save(cmd):
     if platform.system().lower().startswith("win"):
         return
-    if os.environ["SHELL"].endswith("fish"):
+    if shell_adapter.is_fish():
         formatted_line = _get_fish_history_line(cmd)
         history_file = _fish_history_file_location()
         _append_line(formatted_line, history_file)
-    elif os.environ["SHELL"].endswith("zsh"):
+    elif shell_adapter.is_zsh():
         formatted_line = cmd
         history_file = _zsh_history_file_location()
         _append_line(formatted_line, history_file)
-    elif os.environ["SHELL"].endswith("bash"):
+    elif shell_adapter.is_bash():
         formatted_line = cmd
         history_file = _bash_history_file_location()
         _append_line(formatted_line, history_file)

--- a/copilot/history_file.py
+++ b/copilot/history_file.py
@@ -42,16 +42,55 @@ def zsh_history_file_lines():
         return lines
 
 
-def _get_history_line(command_script):
+def bash_history_file_lines():
+    history_file = _bash_history_file_location()
+    if history_file is None:
+        return []
+    with open(history_file, "r") as history:
+        lines = history.readlines()
+        return lines
+
+
+def _bash_history_file_location():
+    possible_paths = [
+        os.path.join(os.environ["HOME"], ".bash_history"),
+    ]
+    for path in possible_paths:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def _get_fish_history_line(command_script):
     return "- cmd: {}\n  when: {}\n".format(command_script, int(time()))
+
+
+def _get_zsh_history_line(command_script):
+    return "{}\n".format(command_script)
+
+
+def _get_bash_history_line(command_script):
+    return "{}\n".format(command_script)
 
 
 def save(cmd):
     if platform.system().lower().startswith("win"):
         return
+    if os.environ["SHELL"].endswith("fish"):
+        formatted_line = _get_fish_history_line(cmd)
+        history_file = _fish_history_file_location()
+        _append_line(formatted_line, history_file)
+    elif os.environ["SHELL"].endswith("zsh"):
+        formatted_line = cmd
+        history_file = _zsh_history_file_location()
+        _append_line(formatted_line, history_file)
+    elif os.environ["SHELL"].endswith("bash"):
+        formatted_line = cmd
+        history_file = _bash_history_file_location()
+        _append_line(formatted_line, history_file)
 
-    history_file = _fish_history_file_location()
+
+def _append_line(formatted_line, history_file):
     if history_file and os.path.isfile(history_file):
         with open(history_file, "a") as history:
-            entry = _get_history_line(cmd)
-            history.write(entry)
+            history.write(formatted_line)

--- a/copilot/main.py
+++ b/copilot/main.py
@@ -10,9 +10,12 @@ import platform
 
 from copilot import history
 
-if platform.system().lower().startswith("lin") or platform.system().lower().startswith(
-    "dar"
-):
+
+def is_unix_system():
+    return platform.system().lower().startswith("lin") or platform.system().lower().startswith("dar")
+
+
+if is_unix_system():
     from simple_term_menu import TerminalMenu
 elif platform.system().lower().startswith("win"):
     import inquirer
@@ -57,9 +60,7 @@ def main():
             environs += f"{key}={os.environ[key]}\n"
 
     operating_system = platform.system()
-    if operating_system.lower().startswith(
-        "lin"
-    ) or operating_system.lower().startswith("dar"):
+    if is_unix_system():
         shell = os.environ.get("SHELL")
     elif operating_system.lower().startswith("win"):
         shell = "cmd"
@@ -80,15 +81,14 @@ The user is currently in the following directory:
 {current_dir}
 That directory contains the following files:
 {directory_list}
-{history.get_history() if args.history and operating_system.lower().startswith("lin") or operating_system.lower().startswith("dar") else ""}
+{history.get_history() if args.history and is_unix_system() else ""}
 The user has several environment variables set, some of which are:
 {environs}
 {git_info() if args.git else ""}
 """
     if (
-        args.alias
-        and operating_system.lower().startswith("lin")
-        or operating_system.lower().startswith("dar")
+            args.alias
+            and is_unix_system()
     ):
         prompt += f"""
 The user has the following aliases set:
@@ -122,9 +122,7 @@ def show_command_options(prompt, cmd):
     print(f"\033[94m> {cmd}\033[0m")
     options = ["execute", "copy", "explainshell", "show more options"]
 
-    if operating_system.lower().startswith(
-        "lin"
-    ) or operating_system.lower().startswith("dar"):
+    if is_unix_system():
         terminal_menu = TerminalMenu(options)
         menu_entry_index = terminal_menu.show()
     elif operating_system.lower().startswith("win"):
@@ -163,9 +161,7 @@ def show_more_cmd_options(prompt):
     print("Here are more options:")
     options = [repr(cmd) for cmd in cmds]
 
-    if operating_system.lower().startswith(
-        "lin"
-    ) or operating_system.lower().startswith("dar"):
+    if is_unix_system():
         cmd_terminal_menu = TerminalMenu(options)
         cmd_menu_entry_index = cmd_terminal_menu.show()
     elif operating_system.lower().startswith("win"):
@@ -208,7 +204,7 @@ def strip_all_whitespaces_from(choices):
 
 def git_info():
     git_installed = (
-        subprocess.run(["which", "git"], capture_output=True).returncode == 0
+            subprocess.run(["which", "git"], capture_output=True).returncode == 0
     )
     if os.path.exists(".git") and git_installed:
         return f"""

--- a/copilot/main.py
+++ b/copilot/main.py
@@ -218,3 +218,7 @@ Short git status:
 """
     else:
         return ""
+
+
+if __name__ == "__main__":
+    main()

--- a/copilot/shell_adapter.py
+++ b/copilot/shell_adapter.py
@@ -1,0 +1,13 @@
+import os
+
+
+def is_fish():
+    return os.environ["SHELL"].endswith("fish")
+
+
+def is_zsh():
+    return os.environ["SHELL"].endswith("zsh")
+
+
+def is_bash():
+    return os.environ["SHELL"].endswith("bash")

--- a/copilot/test_history.py
+++ b/copilot/test_history.py
@@ -7,7 +7,7 @@ from copilot.history import get_history
 
 
 class TestHistory(unittest.TestCase):
-    def test_get_history_add_user_history_context(self):
+    def test_get_history_add_fish_user_history_context(self):
         # arrange
         os.environ["SHELL"] = "/usr/bin/fish"
         # act
@@ -15,6 +15,19 @@ class TestHistory(unittest.TestCase):
             mock_fish_history_file_lines.return_value = [
                 "- cmd: ls\n",
                 "- cmd: cd /home/username\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("The user has recently run these last 2 commands:" in history)
+
+    def test_get_history_adds_zsh_user_history_context(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/zsh"
+        # act
+        with patch('copilot.history_file.zsh_history_file_lines') as mock_zsh_history_file_lines:
+            mock_zsh_history_file_lines.return_value = [
+                ": 1611234567:0;ls",
+                ": 1611234568:0;cd /home/username",
             ]
             history = get_history()
         # assert
@@ -115,3 +128,88 @@ class TestHistory(unittest.TestCase):
         # assert
         self.assertTrue(short_command in history)
         self.assertFalse(long_command in history)
+
+    def test_get_history_returns_empty_string_fish_history_file_is_empty(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('copilot.history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = []
+            history = get_history()
+        # assert
+        self.assertEqual(history, "")
+
+    def test_get_history_returns_empty_string_if_zsh_history_file_is_empty(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/zsh"
+        # act
+        with patch('copilot.history_file.zsh_history_file_lines') as mock_zsh_history_file_lines:
+            mock_zsh_history_file_lines.return_value = []
+            history = get_history()
+        # assert
+        self.assertEqual(history, "")
+
+    def test_get_history_does_not_include_duplicate_fish_commands(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/fish"
+        # act
+        with patch('copilot.history_file.fish_history_file_lines') as mock_fish_history_file_lines:
+            mock_fish_history_file_lines.return_value = [
+                "- cmd: ls\n",
+                "- cmd: ls\n",
+            ]
+            history = get_history()
+        # assert
+        self.assertEqual(history.count("ls"), 1)
+
+    def test_get_history_does_not_include_duplicate_zsh_commands(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/zsh"
+        # act
+        with patch('copilot.history_file.zsh_history_file_lines') as mock_zsh_history_file_lines:
+            mock_zsh_history_file_lines.return_value = [
+                ": 1611234567:0;ls",
+                ": 1611234567:0;ls",
+            ]
+            history = get_history()
+        # assert
+        self.assertEqual(history.count("ls"), 1)
+
+    # bash
+
+    def test_get_history_returns_empty_string_if_bash_history_file_is_empty(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/bash"
+        # act
+        with patch('copilot.history_file.bash_history_file_lines') as mock_bash_history_file_lines:
+            mock_bash_history_file_lines.return_value = []
+            history = get_history()
+        # assert
+        self.assertEqual(history, "")
+
+    def test_get_history_does_not_include_duplicate_bash_commands(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/bash"
+        # act
+        with patch('copilot.history_file.bash_history_file_lines') as mock_bash_history_file_lines:
+            mock_bash_history_file_lines.return_value = [
+                "ls",
+                "ls",
+            ]
+            history = get_history()
+        # assert
+        self.assertEqual(history.count("ls"), 1)
+
+    def test_get_history_processed_bash_history_file(self):
+        # arrange
+        os.environ["SHELL"] = "/usr/bin/bash"
+        # act
+        with patch('copilot.history_file.bash_history_file_lines') as mock_bash_history_file_lines:
+            mock_bash_history_file_lines.return_value = [
+                "ls",
+                "cd /home/username",
+            ]
+            history = get_history()
+        # assert
+        self.assertTrue("ls" in history)
+        self.assertTrue("cd /home/username" in history)

--- a/copilot/test_shell.py
+++ b/copilot/test_shell.py
@@ -1,0 +1,54 @@
+import os
+from unittest import TestCase
+
+from copilot import shell_adapter
+
+
+class Test(TestCase):
+    def test_is_fish_checks_if_SHELL_env_ends_with_fish(self):
+        # arrange
+        for env_shell, expected in [
+            ("fish", True),
+            ("bash", False),
+            ("zsh", False),
+            ("some/path/to/fish", True),
+            ("fish/some", False),
+        ]:
+            with self.subTest(env_shell=env_shell):
+                os.environ["SHELL"] = env_shell
+                # act
+                is_fish = shell_adapter.is_fish()
+                # assert
+                self.assertEqual(is_fish, expected)
+
+    def test_is_zsh_checks_if_SHELL_env_ends_with_zsh(self):
+        # arrange
+        for env_shell, expected in [
+            ("fish", False),
+            ("bash", False),
+            ("zsh", True),
+            ("some/path/to/zsh", True),
+            ("zsh/some", False),
+        ]:
+            with self.subTest(env_shell=env_shell):
+                os.environ["SHELL"] = env_shell
+                # act
+                zsh = shell_adapter.is_zsh()
+                # assert
+                self.assertEqual(zsh, expected)
+
+    def test_is_bash_checks_if_SHELL_env_ends_with_bash(self):
+        # arrange
+        for env_shell, expected in [
+            ("fish", False),
+            ("bash", True),
+            ("zsh", False),
+            ("some/path/to/bash", True),
+            ("bash/some", False),
+        ]:
+            with self.subTest(env_shell=env_shell):
+                os.environ["SHELL"] = env_shell
+                # act
+                bash = shell_adapter.is_bash()
+                # assert
+                self.assertEqual(bash, expected)


### PR DESCRIPTION
This PR implements the history for bash terminals. I also fixed a bug in main.py in which the history/alias would be send always to OpenAI independent of the configured flags.