### PR TITLE
Patch for Python 3.8.10

### DIFF
--- a/copilot/context.py
+++ b/copilot/context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 from copilot.conversation import Model
 from copilot.parse_os import OperatingSystem
@@ -9,7 +10,7 @@ class Context:
     shell: str
     operating_system: OperatingSystem
     directory: str
-    directory_list: list[str]
+    directory_list: List[str]
     history: str
     command: str
     git: str

--- a/copilot/conversation.py
+++ b/copilot/conversation.py
@@ -1,6 +1,7 @@
 import argparse
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Dict
 
 
 class Model(Enum):
@@ -18,5 +19,5 @@ def argparse_model_type(model_str):
 
 @dataclass
 class Conversation:
-    messages: list[dict]
+    messages: List[Dict]
     model: Model


### PR DESCRIPTION
This quick update makes `terminal-copilot` work with Python 3.8.10 which changed around `list` and `dict` keyword usage I believe.